### PR TITLE
Make project description clearer in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Logo](docs/images/app-title.png)
 
-A text editor that uses [interpolated strings](https://en.wikipedia.org/wiki/String_interpolation) to reference externally defined values.
+An editor for [Markdown](https://en.wikipedia.org/wiki/Markdown)-based documents in which you can write [interpolated strings](https://en.wikipedia.org/wiki/String_interpolation) to reference externally defined values.
 
 ## Download
 


### PR DESCRIPTION
The original phrase “a text editor” made me think of a general-purpose text editor, like Vim or VS Code, which this doesn’t seem to be.

I based this description on the GitHub repo’s description. However, I used different wording because I thought you might have been trying to make the README’s description less technical.