### PR TITLE
127 convert straight quotes finetuned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ video
 .classpath
 .idea
 themes
+out/
+gradle/
+gradlew
+gradlew.bat

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+  id 'antlr'
   id 'application'
   id 'org.openjfx.javafxplugin' version '0.0.9'
   id 'com.palantir.git-version' version '0.12.3'
@@ -127,6 +128,13 @@ dependencies {
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
   testImplementation "org.testfx:testfx-junit5:4.0.16-alpha"
+
+  antlr "org.antlr:antlr4:4.9.2"
+}
+
+generateGrammarSource {
+  maxHeapSize = "128m"
+  arguments += ["-visitor", "-package", "com.keenwrite.quotes"]
 }
 
 compileJava {

--- a/src/main/antlr/com/keenwrite/quotes/English.g4
+++ b/src/main/antlr/com/keenwrite/quotes/English.g4
@@ -1,0 +1,186 @@
+grammar English;
+
+document
+ : newLine* paragraphs? newLine* EOF
+ ;
+
+paragraphs
+ : paragraph ( newLine newLine+ paragraph )*
+ ;
+
+paragraph
+ : sentence ( terminator+ Space* sentence )* terminator* Space*
+ ;
+
+sentence
+ : atom ( separator+ atom )*
+ ;
+
+atom
+ : word
+ | height       // Match a height before a contraction, otherwise 5' would become a contraction
+ | contraction  // Match a contraction before a quotation, otherwise 'n' would become a quotation
+ | quotation
+ | orphanedOpeningDQuote atom
+ | ~( Apostrophe | QuotationMark | BackQuote )
+ ;
+
+contraction
+ : word ( apostrophe word )+        // y'all'll'nt've'd's
+ | apostrophe word                  // 'll, 've
+ | apostrophe Digits word?          // '04, '20s
+ | word apostrophe                  // thinkin'
+ | apostrophe character apostrophe  // fish 'n' chips
+ ;
+
+// FIXME: can this only occur with back-quotes? If any double quote is supposed to be supported, simple use `openingDQuote`
+orphanedOpeningDQuote
+ : BackQuote BackQuote
+ ;
+
+quotation
+ : openingSQuote innerQuotation closingSQuote    // '...'
+ | openingDQuote1 innerQuotation closingDQuote1  // "..."
+ | openingDQuote2 innerQuotation closingDQuote2  // ''...''
+ | openingDQuote3 innerQuotation closingDQuote2  // ``...''
+ ;
+
+// Important that there is both a non-space to the right of the start-quote and one to the left end-quote
+innerQuotation
+ : non_space ( atom* non_space )?
+ ;
+
+non_space
+ : height
+ | contraction
+ | quotation
+ | ~( Space | NewLine )
+ ;
+
+height
+ : number sPrime ( number dPrime )?
+ | number dPrime
+ ;
+
+apostrophe
+ : Apostrophe
+ ;
+
+openingSQuote
+ : Apostrophe
+ ;
+
+closingSQuote
+ : Apostrophe
+ ;
+
+openingDQuote1
+ : QuotationMark
+ ;
+
+closingDQuote1
+ : QuotationMark
+ ;
+
+openingDQuote2
+ : Apostrophe Apostrophe
+ ;
+
+closingDQuote2
+ : Apostrophe Apostrophe
+ ;
+
+openingDQuote3
+ : BackQuote BackQuote
+ ;
+
+sPrime
+ : Backslash? Apostrophe
+ ;
+
+dPrime
+ : Backslash? QuotationMark
+ | Apostrophe Apostrophe
+ ;
+
+terminator
+ : ExclamationMark
+ | FullStop
+ | QuestionMark
+ ;
+
+character
+ : Character
+ | X
+ ;
+
+word
+ : Word
+ | Character
+ | Digits
+ | X
+ ;
+
+number
+ : Decimal
+ | Digits
+ ;
+
+separator
+ : Space+
+ | Comma
+ | X
+ | Other
+ ;
+
+newLine
+ : Space* NewLine Space*
+ ;
+
+DEBUG
+ : '//' ~[\r\n]* -> skip
+ ;
+
+Apostrophe      : '\'';
+QuotationMark   : '"';
+ExclamationMark : '!';
+FullStop        : '.';
+QuestionMark    : '?';
+Comma           : ',';
+Backslash       : '\\';
+BackQuote       : '`';
+
+Digits
+ : [0-9]+
+ ;
+
+// The '.' needs to be part of the token, otherwise it conflicts with the full stop that eends a sentence
+Decimal
+ : Digits '.' Digits
+ ;
+
+X
+ : [xX]
+ ;
+
+Character
+ : [\p{Alpha}\p{General_Category=Other_Letter}]
+ ;
+
+Word
+ : Character+
+ ;
+
+NewLine
+ : '\r'? '\n'
+ | '\r'
+ ;
+
+Space
+ : [ \t]
+ ;
+
+Other
+ : .
+ ;
+

--- a/src/main/antlr/com/keenwrite/quotes/English.g4
+++ b/src/main/antlr/com/keenwrite/quotes/English.g4
@@ -13,15 +13,15 @@ paragraph
  ;
 
 sentence
- : atom ( separator+ atom )*
+ : atom+ ( separator+ atom+ )*
  ;
 
 atom
- : word
- | height       // Match a height before a contraction, otherwise 5' would become a contraction
+ : height       // Match a height before a contraction, otherwise 5' would become a contraction
  | contraction  // Match a contraction before a quotation, otherwise 'n' would become a quotation
  | quotation
- | orphanedOpeningDQuote atom
+ | orphanedOpeningQuote atom
+ | word
  | ~( Apostrophe | QuotationMark | BackQuote )
  ;
 
@@ -33,11 +33,6 @@ contraction
  | apostrophe character apostrophe  // fish 'n' chips
  ;
 
-// FIXME: can this only occur with back-quotes? If any double quote is supposed to be supported, simple use `openingDQuote`
-orphanedOpeningDQuote
- : BackQuote BackQuote
- ;
-
 quotation
  : openingSQuote innerQuotation closingSQuote    // '...'
  | openingDQuote1 innerQuotation closingDQuote1  // "..."
@@ -45,16 +40,18 @@ quotation
  | openingDQuote3 innerQuotation closingDQuote2  // ``...''
  ;
 
-// Important that there is both a non-space to the right of the start-quote and one to the left end-quote
 innerQuotation
- : non_space ( atom* non_space )?
+ :  restricted_atom ( atom* restricted_atom )?
  ;
 
-non_space
+restricted_atom
  : height
- | contraction
- | quotation
- | ~( Space | NewLine )
+// | contraction  //   ,---> fails: "'I'm trouble.'"
+// | quotation    //  /
+ | quotation      //  \
+ | contraction    //   '---> fails: "'Twas, t'wasn't thy name, 'twas it?" said Jim "the Barber" Brown.
+ | word
+ | ~( Space | NewLine | Apostrophe | QuotationMark | BackQuote | Backslash )
  ;
 
 height
@@ -62,24 +59,30 @@ height
  | number dPrime
  ;
 
+orphanedOpeningQuote
+ : openingDQuote1
+ | openingDQuote2
+ | openingDQuote3
+ ;
+
 apostrophe
- : Apostrophe
+ : Backslash? Apostrophe
  ;
 
 openingSQuote
- : Apostrophe
+ : Backslash? Apostrophe
  ;
 
 closingSQuote
- : Apostrophe
+ : Backslash? Apostrophe
  ;
 
 openingDQuote1
- : QuotationMark
+ : Backslash? QuotationMark
  ;
 
 closingDQuote1
- : QuotationMark
+ : Backslash? QuotationMark
  ;
 
 openingDQuote2

--- a/src/main/java/com/keenwrite/quotes/EnglishQuotesListener.java
+++ b/src/main/java/com/keenwrite/quotes/EnglishQuotesListener.java
@@ -1,5 +1,7 @@
 package com.keenwrite.quotes;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 public class EnglishQuotesListener extends EnglishBaseListener {
@@ -13,13 +15,71 @@ public class EnglishQuotesListener extends EnglishBaseListener {
 
   @Override
   public void visitTerminal(TerminalNode node) {
+    if (node.getSymbol().getType() == Token.EOF) {
+      return;
+    }
+
     if (this.skipNextTerminals > 0) {
       this.skipNextTerminals--;
       return;
     }
 
     this.builder.append(node.getText());
+  }
 
-    System.out.println(node.getText().replace("\n", "\\n"));
+  @Override
+  public void enterApostrophe(EnglishParser.ApostropheContext ctx) {
+    this.appendText("&apos;", ctx);
+  }
+
+  @Override
+  public void enterOpeningSQuote(EnglishParser.OpeningSQuoteContext ctx) {
+    this.appendText("&lsquo;", ctx);
+  }
+
+  @Override
+  public void enterClosingSQuote(EnglishParser.ClosingSQuoteContext ctx) {
+    this.appendText("&rsquo;", ctx);
+  }
+
+  @Override
+  public void enterOpeningDQuote1(EnglishParser.OpeningDQuote1Context ctx) {
+    this.appendText("&ldquo;", ctx);
+  }
+
+  @Override
+  public void enterClosingDQuote1(EnglishParser.ClosingDQuote1Context ctx) {
+    this.appendText("&rdquo;", ctx);
+  }
+
+  @Override
+  public void enterOpeningDQuote2(EnglishParser.OpeningDQuote2Context ctx) {
+    this.appendText("&ldquo;", ctx);
+  }
+
+  @Override
+  public void enterClosingDQuote2(EnglishParser.ClosingDQuote2Context ctx) {
+    this.appendText("&rdquo;", ctx);
+  }
+
+  @Override
+  public void enterOpeningDQuote3(EnglishParser.OpeningDQuote3Context ctx) {
+    this.appendText("&ldquo;", ctx);
+  }
+
+  @Override
+  public void enterSPrime(EnglishParser.SPrimeContext ctx) {
+    this.appendText("&prime;", ctx);
+  }
+
+  @Override
+  public void enterDPrime(EnglishParser.DPrimeContext ctx) {
+    this.appendText("&Prime;", ctx);
+  }
+
+  private void appendText(String text, ParserRuleContext ctx) {
+    this.builder.append(text);
+
+    this.skipNextTerminals += ctx.getChildCount();
   }
 }

--- a/src/main/java/com/keenwrite/quotes/EnglishQuotesListener.java
+++ b/src/main/java/com/keenwrite/quotes/EnglishQuotesListener.java
@@ -1,0 +1,25 @@
+package com.keenwrite.quotes;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+public class EnglishQuotesListener extends EnglishBaseListener {
+
+  private final StringBuilder builder = new StringBuilder();
+  private int skipNextTerminals = 0;
+
+  public String rewrittenText() {
+    return this.builder.toString();
+  }
+
+  @Override
+  public void visitTerminal(TerminalNode node) {
+    if (this.skipNextTerminals > 0) {
+      this.skipNextTerminals--;
+      return;
+    }
+
+    this.builder.append(node.getText());
+
+    System.out.println(node.getText().replace("\n", "\\n"));
+  }
+}

--- a/src/test/java/com/keenwrite/quotes/EnglishParserTest.java
+++ b/src/test/java/com/keenwrite/quotes/EnglishParserTest.java
@@ -1,0 +1,338 @@
+package com.keenwrite.quotes;
+
+import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class EnglishParserTest {
+
+  String[][] tests = {
+      {
+          "The Roaring '20s had the best music, no?",
+          "The Roaring &apos;20s had the best music, no?"
+      },
+      {
+          "Took place in '04, yes'm!",
+          "Took place in &apos;04, yes&apos;m!"
+      },
+      {
+          "I don't like it: I love's it!",
+          "I don&apos;t like it: I love&apos;s it!"
+      },
+      {
+          "We'd've thought that pancakes'll be sweeter there.",
+          "We&apos;d&apos;ve thought that pancakes&apos;ll be sweeter there."
+      },
+      {
+          "She'd be coming o'er when the horse'd gone to pasture...",
+          "She&apos;d be coming o&apos;er when the horse&apos;d gone to pasture..."
+      },
+      {
+          "'Twas and 'tis whate'er lay 'twixt dawn and dusk 'n River Styx.",
+          "&apos;Twas and &apos;tis whate&apos;er lay &apos;twixt dawn and dusk &apos;n River Styx."
+      },
+      {
+          "Didn' get th' message.",
+          "Didn&apos; get th&apos; message."
+      },
+      {
+          "Namsayin', y'know what I'ma sayin'?",
+          "Namsayin&apos;, y&apos;know what I&apos;ma sayin&apos;?"
+      },
+      {
+          "Salt 'n' vinegar, fish-'n'-chips, sugar 'n' spice!",
+          "Salt &apos;n&apos; vinegar, fish-&apos;n&apos;-chips, sugar &apos;n&apos; spice!"
+      },
+      {
+          "She stood 5\\'7\\\".",
+          "She stood 5&prime;7&Prime;."
+      },
+      {
+          "It's 4'11\" away.",
+          "It&apos;s 4&prime;11&Prime; away."
+      },
+      {
+          "Alice's friend is 6'3\" tall.",
+          "Alice&apos;s friend is 6&prime;3&Prime; tall."
+      },
+      {
+          "Bob's table is 5'' × 4''.",
+          "Bob&apos;s table is 5&Prime; × 4&Prime;."
+      },
+      {
+          "What's this -5.5'' all about?",
+          "What&apos;s this -5.5&Prime; all about?"
+      },
+      {
+          "+7.9'' is weird.",
+          "+7.9&Prime; is weird."
+      },
+      {
+          "Foolscap? Naw, I use 11.5\"x14.25\" paper!",
+          "Foolscap? Naw, I use 11.5&Prime;x14.25&Prime; paper!"
+      },
+      {
+          "An angular measurement, 3° 5' 30\" means 3 degs, 5 arcmins, and 30 arcsecs.",
+          "An angular measurement, 3° 5&prime; 30&Prime; means 3 degs, 5 arcmins, and 30 arcsecs."
+      },
+      {
+          "``I am Sam''",
+          "&ldquo;I am Sam&rdquo;"
+      },
+      {
+          "``Sam's away today''",
+          "&ldquo;Sam&apos;s away today&rdquo;"
+      },
+      {
+          "``Sam's gone!",
+          "&ldquo;Sam&apos;s gone!"
+      },
+      {
+          "``5'10\" tall 'e was!''",
+          "&ldquo;5&prime;10&Prime; tall &apos;e was!&rdquo;"
+      },
+      {
+          "\"'I'm trouble.'\"",
+          "&ldquo;&lsquo;I&apos;m trouble.&rsquo;&rdquo;"
+      },
+      {
+          "'\"Trouble's my name.\"'",
+          "&lsquo;&ldquo;Trouble&apos;s my name.&ldquo;&lsquo;"
+      },
+      {
+          "\\\"What?\\\"",
+          "&ldquo;What?&rdquo;"
+      },
+      {
+          "\"I am Sam\"",
+          "&ldquo;I am Sam&rdquo;"
+      },
+      {
+          "\"...even better!\"",
+          "&ldquo;...even better!&rdquo;"
+      },
+      {
+          "\"It was so,\" said he.",
+          "&ldquo;It was so,&rdquo; said he."
+      },
+      {
+          "\"She said, 'Llamas'll languish, they'll--",
+          "&ldquo;She said, &lsquo;Llamas&apos;ll languish, they&apos;ll--"
+      },
+      {
+          "With \"air quotes\" in the middle.",
+          "With &ldquo;air quotes&rdquo; in the middle."
+      },
+      {
+          "With--\"air quotes\"--and dashes.",
+          "With--&ldquo;air quotes&rdquo;--and dashes."
+      },
+      {
+          "\"Not \"quite\" what you expected?\"",
+          "&ldquo;Not &ldquo;quite&rdquo; what you expected?&rdquo;"
+      },
+      {
+          "\"'Here I am,' said Sam\"",
+          "&ldquo;&lsquo;Here I am,&rsquo; said Sam&rdquo;"
+      },
+      {
+          "'\"Here I am,\" said Sam'",
+          "&lsquo;&ldquo;Here I am,&rdquo;, said Sam&rsquo;"
+      },
+      {
+          "'Hello, \"Dr. Brown,\" what's your real name?'",
+          "&lsquo;Hello, &ldquo;Dr. Brown,&rdquo; what's your real name?&rsquo;"
+      },
+      {
+          "\"'Twas, t'wasn't thy name, 'twas it?\" said Jim \"the Barber\" Brown.",
+          "&ldquo;&apos;Twas, t&apos;wasn&apos;t thy name, &apos;twas it?&rdquo; said Jim &ldquo;the Barber&rdquo; Brown."
+      },
+      {
+          "'I am Sam'",
+          "&lsquo;I am Sam&rsquo;"
+      },
+      {
+          "'It was so,' said he.",
+          "&lsquo;It was so,&rsquo; said he."
+      },
+      {
+          "'...even better!'",
+          "&lsquo;...even better!&rsquo;"
+      },
+      {
+          "With 'quotes' in the middle.",
+          "With &lsquo;quotes&rsquo; in the middle."
+      },
+      {
+          "With--'imaginary'--dashes.",
+          "With--&lsquo;imaginary&rsquo;--dashes."
+      },
+      {
+          "'Not 'quite' what you expected?'",
+          "&lsquo;Not &lsquo;quite&rsquo; what you expected?&rsquo;"
+      },
+      {
+          "''Cause I don't like it, 's why,' said Pat.",
+          "&lsquo;&apos;Cause I don't like it, &apos;s why,&rsquo; said Pat."
+      },
+      {
+          "'It's a beautiful day!'",
+          "&lsquo;It&apos;s a beautiful day!&rsquo;"
+      },
+      {
+          "'He said, 'Thinkin'.'",
+          "&lsquo;He said, &lsquo;Thinkin&rsquo;.&rsquo;"
+      },
+      {
+          "Sam's Sams' and the Ross's roses' thorns were prickly.",
+          "Sam&apos;s Sams&apos; and the Ross&apos;s roses&apos; thorns were prickly."
+      },
+      {
+          "\"I heard she said, 'That's Sam's',\" said the Sams' cat.",
+          "&ldquo;I heard she said, &lsquo;That&apos;s Sam&apos;s&rsquo;,&rdquo; said the Sams&apos; cat."
+      },
+      {
+          "\"'Janes' said, ''E'll be spooky, Sam's son with the jack-o'-lantern!'\" said the O'Mally twins'---y'know---ghosts in unison.",
+          "&ldquo;&lsquo;Janes&apos; said, &lsquo;&apos;E&apos;ll be spooky, Sam&apos;s son with the jack-o&apos;-lantern!&rsquo;&rdquo; said the O&apos;Mally twins&apos;---y&apos;know---ghosts in unison."
+      },
+      {
+          "'He's at Sams'",
+          "&lsquo;He&apos; at Sams&rsquo;"
+      },
+      {
+          "\\\"Hello!\\\"",
+          "&ldquo;Hello!&rdquo;"
+      },
+      {
+          "ma'am",
+          "ma&apos;am"
+      },
+      {
+          "'Twas midnight",
+          "&apos;Twas midnight"
+      },
+      {
+          "\\\"Hello,\\\" said the spider. \\\"'Shelob' is my name.\\\"",
+          "&ldquo;Hello,&rdquo; said the spider. &ldquo;&lsquo;Shelob&rsquo; is my name.&rdquo;"
+      },
+      {
+          "'A', 'B', and 'C' are letters.",
+          "&lsquo;A&rsquo; &lsquo;B&rsquo; and &lsquo;C&rsquo; are letters."
+      },
+      {
+          "'Oak,' 'elm,' and 'beech' are names of trees. So is 'pine.'",
+          "&lsquo;Oak,&rsquo; &lsquo;elm,&rsquo; and &lsquo;beech&rsquo; are names of trees. So is &lsquo;pine.&rsquo;"
+      },
+      {
+          "'He said, \\\"I want to go.\\\"' Were you alive in the 70's?",
+          "&lsquo;He said, &ldquo;I want to go.&rdquo;&rsquo; Were you alive in the 70&apos;s?"
+      },
+      {
+          "\\\"That's a 'magic' sock.\\\"",
+          "&ldquo;That&apos;s a &lsquo;magic&rsquo; sock.&rdquo;"
+      },
+      {
+          "Website! Company Name, Inc. (\\\"Company Name\\\" or \\\"Company\\\") recommends reading the following terms and conditions, carefully:",
+          "Website! Company Name, Inc. (&ldquo;Company Name&rdquo; or &ldquo;Company&rdquo;) recommends reading the following terms and conditions, carefully:"
+      },
+      {
+          "Website! Company Name, Inc. ('Company Name' or 'Company') recommends reading the following terms and conditions, carefully:",
+          "Website! Company Name, Inc. (&lsquo;Company Name&rsquo; or &lsquo;Company&rsquo;) recommends reading the following terms and conditions, carefully:"
+      },
+      {
+          "Workin' hard",
+          "Workin&apos; hard"
+      },
+      {
+          "'70s are my favorite numbers,' she said.",
+          "&lsquo;70s are my favorite numbers,&rsquo; she said."
+      },
+      {
+          "'70s fashion was weird.",
+          "&apos;70s fashion was weird."
+      },
+      {
+          "12\\\" record, 5'10\\\" height",
+          "12&Prime; record, 5&prime;10&Prime; height"
+      },
+      {
+          "Model \\\"T2000\\\"",
+          "Model &ldquo;T2000&rdquo;"
+      },
+      {
+          "iPad 3's battery life is not great.",
+          "iPad 3&apos;s battery life is not great."
+      },
+      {
+          "Book 'em, Danno. Rock 'n' roll. 'Cause 'twas the season.",
+          "Book &apos;em, Danno. Rock &apos;n&apos; roll. &apos;Cause &apos;twas the season."
+      },
+      {
+          "'85 was a good year. (The entire '80s were.)",
+          "&apos;85 was a good year. (The entire &apos;80s were.)"
+      }
+  };
+
+  @Test
+  public void testDumpTokens() {
+    String text = "music,";
+    List<Token> tokens = tokens(text);
+
+    for (Token t : tokens) {
+      System.out.printf("%-15s '%s'\n", EnglishLexer.VOCABULARY.getSymbolicName(t.getType()), t.getText());
+    }
+  }
+
+  @Test
+  public void tokenizeSmartypantsExamplesSuccessfully() {
+    for (String[] test : tests) {
+      List<Token> tokens = tokens(test[0]);
+
+      for (Token t : tokens) {
+        if (t.getType() == EnglishLexer.Other) {
+          fail("Stumbled upon an unknown char in the lexer: " + t.getText());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void parseSmartypantsExamplesSuccessfully() {
+    for (String[] test : tests) {
+      try {
+        parser(test[0]).document();
+      }
+      catch (Exception e) {
+        fail("Could not parse: " + test[0]);
+      }
+    }
+  }
+
+  private static List<Token> tokens(String text) {
+    EnglishLexer lexer = new EnglishLexer(CharStreams.fromString(text));
+
+    CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+    tokenStream.fill();
+
+    return tokenStream.getTokens();
+  }
+
+  private static EnglishParser parser(String text) {
+    EnglishLexer lexer = new EnglishLexer(CharStreams.fromString(text));
+    EnglishParser parser = new EnglishParser(new CommonTokenStream(lexer));
+
+    // Remove error listeners that possibly try to recover from syntax errors
+    parser.removeErrorListeners();
+
+    // On any syntax error, we'll let an exception be thrown by using BailErrorStrategy
+    parser.setErrorHandler(new BailErrorStrategy());
+
+    return parser;
+  }
+}

--- a/src/test/java/com/keenwrite/quotes/EnglishParserTest.java
+++ b/src/test/java/com/keenwrite/quotes/EnglishParserTest.java
@@ -6,324 +6,48 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class EnglishParserTest {
 
-  String[][] tests = {
-      {
-          "The Roaring '20s had the best music, no?",
-          "The Roaring &apos;20s had the best music, no?"
-      },
-      {
-          "Took place in '04, yes'm!",
-          "Took place in &apos;04, yes&apos;m!"
-      },
-      {
-          "I don't like it: I love's it!",
-          "I don&apos;t like it: I love&apos;s it!"
-      },
-      {
-          "We'd've thought that pancakes'll be sweeter there.",
-          "We&apos;d&apos;ve thought that pancakes&apos;ll be sweeter there."
-      },
-      {
-          "She'd be coming o'er when the horse'd gone to pasture...",
-          "She&apos;d be coming o&apos;er when the horse&apos;d gone to pasture..."
-      },
-      {
-          "'Twas and 'tis whate'er lay 'twixt dawn and dusk 'n River Styx.",
-          "&apos;Twas and &apos;tis whate&apos;er lay &apos;twixt dawn and dusk &apos;n River Styx."
-      },
-      {
-          "Didn' get th' message.",
-          "Didn&apos; get th&apos; message."
-      },
-      {
-          "Namsayin', y'know what I'ma sayin'?",
-          "Namsayin&apos;, y&apos;know what I&apos;ma sayin&apos;?"
-      },
-      {
-          "Salt 'n' vinegar, fish-'n'-chips, sugar 'n' spice!",
-          "Salt &apos;n&apos; vinegar, fish-&apos;n&apos;-chips, sugar &apos;n&apos; spice!"
-      },
-      {
-          "She stood 5\\'7\\\".",
-          "She stood 5&prime;7&Prime;."
-      },
-      {
-          "It's 4'11\" away.",
-          "It&apos;s 4&prime;11&Prime; away."
-      },
-      {
-          "Alice's friend is 6'3\" tall.",
-          "Alice&apos;s friend is 6&prime;3&Prime; tall."
-      },
-      {
-          "Bob's table is 5'' × 4''.",
-          "Bob&apos;s table is 5&Prime; × 4&Prime;."
-      },
-      {
-          "What's this -5.5'' all about?",
-          "What&apos;s this -5.5&Prime; all about?"
-      },
-      {
-          "+7.9'' is weird.",
-          "+7.9&Prime; is weird."
-      },
-      {
-          "Foolscap? Naw, I use 11.5\"x14.25\" paper!",
-          "Foolscap? Naw, I use 11.5&Prime;x14.25&Prime; paper!"
-      },
-      {
-          "An angular measurement, 3° 5' 30\" means 3 degs, 5 arcmins, and 30 arcsecs.",
-          "An angular measurement, 3° 5&prime; 30&Prime; means 3 degs, 5 arcmins, and 30 arcsecs."
-      },
-      {
-          "``I am Sam''",
-          "&ldquo;I am Sam&rdquo;"
-      },
-      {
-          "``Sam's away today''",
-          "&ldquo;Sam&apos;s away today&rdquo;"
-      },
-      {
-          "``Sam's gone!",
-          "&ldquo;Sam&apos;s gone!"
-      },
-      {
-          "``5'10\" tall 'e was!''",
-          "&ldquo;5&prime;10&Prime; tall &apos;e was!&rdquo;"
-      },
-      {
-          "\"'I'm trouble.'\"",
-          "&ldquo;&lsquo;I&apos;m trouble.&rsquo;&rdquo;"
-      },
-      {
-          "'\"Trouble's my name.\"'",
-          "&lsquo;&ldquo;Trouble&apos;s my name.&ldquo;&lsquo;"
-      },
-      {
-          "\\\"What?\\\"",
-          "&ldquo;What?&rdquo;"
-      },
-      {
-          "\"I am Sam\"",
-          "&ldquo;I am Sam&rdquo;"
-      },
-      {
-          "\"...even better!\"",
-          "&ldquo;...even better!&rdquo;"
-      },
-      {
-          "\"It was so,\" said he.",
-          "&ldquo;It was so,&rdquo; said he."
-      },
-      {
-          "\"She said, 'Llamas'll languish, they'll--",
-          "&ldquo;She said, &lsquo;Llamas&apos;ll languish, they&apos;ll--"
-      },
-      {
-          "With \"air quotes\" in the middle.",
-          "With &ldquo;air quotes&rdquo; in the middle."
-      },
-      {
-          "With--\"air quotes\"--and dashes.",
-          "With--&ldquo;air quotes&rdquo;--and dashes."
-      },
-      {
-          "\"Not \"quite\" what you expected?\"",
-          "&ldquo;Not &ldquo;quite&rdquo; what you expected?&rdquo;"
-      },
-      {
-          "\"'Here I am,' said Sam\"",
-          "&ldquo;&lsquo;Here I am,&rsquo; said Sam&rdquo;"
-      },
-      {
-          "'\"Here I am,\" said Sam'",
-          "&lsquo;&ldquo;Here I am,&rdquo;, said Sam&rsquo;"
-      },
-      {
-          "'Hello, \"Dr. Brown,\" what's your real name?'",
-          "&lsquo;Hello, &ldquo;Dr. Brown,&rdquo; what's your real name?&rsquo;"
-      },
-      {
-          "\"'Twas, t'wasn't thy name, 'twas it?\" said Jim \"the Barber\" Brown.",
-          "&ldquo;&apos;Twas, t&apos;wasn&apos;t thy name, &apos;twas it?&rdquo; said Jim &ldquo;the Barber&rdquo; Brown."
-      },
-      {
-          "'I am Sam'",
-          "&lsquo;I am Sam&rsquo;"
-      },
-      {
-          "'It was so,' said he.",
-          "&lsquo;It was so,&rsquo; said he."
-      },
-      {
-          "'...even better!'",
-          "&lsquo;...even better!&rsquo;"
-      },
-      {
-          "With 'quotes' in the middle.",
-          "With &lsquo;quotes&rsquo; in the middle."
-      },
-      {
-          "With--'imaginary'--dashes.",
-          "With--&lsquo;imaginary&rsquo;--dashes."
-      },
-      {
-          "'Not 'quite' what you expected?'",
-          "&lsquo;Not &lsquo;quite&rsquo; what you expected?&rsquo;"
-      },
-      {
-          "''Cause I don't like it, 's why,' said Pat.",
-          "&lsquo;&apos;Cause I don't like it, &apos;s why,&rsquo; said Pat."
-      },
-      {
-          "'It's a beautiful day!'",
-          "&lsquo;It&apos;s a beautiful day!&rsquo;"
-      },
-      {
-          "'He said, 'Thinkin'.'",
-          "&lsquo;He said, &lsquo;Thinkin&rsquo;.&rsquo;"
-      },
-      {
-          "Sam's Sams' and the Ross's roses' thorns were prickly.",
-          "Sam&apos;s Sams&apos; and the Ross&apos;s roses&apos; thorns were prickly."
-      },
-      {
-          "\"I heard she said, 'That's Sam's',\" said the Sams' cat.",
-          "&ldquo;I heard she said, &lsquo;That&apos;s Sam&apos;s&rsquo;,&rdquo; said the Sams&apos; cat."
-      },
-      {
-          "\"'Janes' said, ''E'll be spooky, Sam's son with the jack-o'-lantern!'\" said the O'Mally twins'---y'know---ghosts in unison.",
-          "&ldquo;&lsquo;Janes&apos; said, &lsquo;&apos;E&apos;ll be spooky, Sam&apos;s son with the jack-o&apos;-lantern!&rsquo;&rdquo; said the O&apos;Mally twins&apos;---y&apos;know---ghosts in unison."
-      },
-      {
-          "'He's at Sams'",
-          "&lsquo;He&apos; at Sams&rsquo;"
-      },
-      {
-          "\\\"Hello!\\\"",
-          "&ldquo;Hello!&rdquo;"
-      },
-      {
-          "ma'am",
-          "ma&apos;am"
-      },
-      {
-          "'Twas midnight",
-          "&apos;Twas midnight"
-      },
-      {
-          "\\\"Hello,\\\" said the spider. \\\"'Shelob' is my name.\\\"",
-          "&ldquo;Hello,&rdquo; said the spider. &ldquo;&lsquo;Shelob&rsquo; is my name.&rdquo;"
-      },
-      {
-          "'A', 'B', and 'C' are letters.",
-          "&lsquo;A&rsquo; &lsquo;B&rsquo; and &lsquo;C&rsquo; are letters."
-      },
-      {
-          "'Oak,' 'elm,' and 'beech' are names of trees. So is 'pine.'",
-          "&lsquo;Oak,&rsquo; &lsquo;elm,&rsquo; and &lsquo;beech&rsquo; are names of trees. So is &lsquo;pine.&rsquo;"
-      },
-      {
-          "'He said, \\\"I want to go.\\\"' Were you alive in the 70's?",
-          "&lsquo;He said, &ldquo;I want to go.&rdquo;&rsquo; Were you alive in the 70&apos;s?"
-      },
-      {
-          "\\\"That's a 'magic' sock.\\\"",
-          "&ldquo;That&apos;s a &lsquo;magic&rsquo; sock.&rdquo;"
-      },
-      {
-          "Website! Company Name, Inc. (\\\"Company Name\\\" or \\\"Company\\\") recommends reading the following terms and conditions, carefully:",
-          "Website! Company Name, Inc. (&ldquo;Company Name&rdquo; or &ldquo;Company&rdquo;) recommends reading the following terms and conditions, carefully:"
-      },
-      {
-          "Website! Company Name, Inc. ('Company Name' or 'Company') recommends reading the following terms and conditions, carefully:",
-          "Website! Company Name, Inc. (&lsquo;Company Name&rsquo; or &lsquo;Company&rsquo;) recommends reading the following terms and conditions, carefully:"
-      },
-      {
-          "Workin' hard",
-          "Workin&apos; hard"
-      },
-      {
-          "'70s are my favorite numbers,' she said.",
-          "&lsquo;70s are my favorite numbers,&rsquo; she said."
-      },
-      {
-          "'70s fashion was weird.",
-          "&apos;70s fashion was weird."
-      },
-      {
-          "12\\\" record, 5'10\\\" height",
-          "12&Prime; record, 5&prime;10&Prime; height"
-      },
-      {
-          "Model \\\"T2000\\\"",
-          "Model &ldquo;T2000&rdquo;"
-      },
-      {
-          "iPad 3's battery life is not great.",
-          "iPad 3&apos;s battery life is not great."
-      },
-      {
-          "Book 'em, Danno. Rock 'n' roll. 'Cause 'twas the season.",
-          "Book &apos;em, Danno. Rock &apos;n&apos; roll. &apos;Cause &apos;twas the season."
-      },
-      {
-          "'85 was a good year. (The entire '80s were.)",
-          "&apos;85 was a good year. (The entire &apos;80s were.)"
-      }
-  };
-
   @Test
-  public void testDumpTokens() {
-    String text = "music,";
-    List<Token> tokens = tokens(text);
+  public void testParserForSyntaxErrors() throws IOException {
+    try( final var reader = openResource( "smartypants.txt" ) ) {
+      String line;
 
-    for (Token t : tokens) {
-      System.out.printf("%-15s '%s'\n", EnglishLexer.VOCABULARY.getSymbolicName(t.getType()), t.getText());
-    }
-  }
+      while( ((line = reader.readLine()) != null) ) {
+        if (line.trim().isBlank() || line.trim().startsWith("#")) {
+          continue;
+        }
 
-  @Test
-  public void tokenizeSmartypantsExamplesSuccessfully() {
-    for (String[] test : tests) {
-      List<Token> tokens = tokens(test[0]);
+        // Discard the expected line
+        reader.readLine();
 
-      for (Token t : tokens) {
-        if (t.getType() == EnglishLexer.Other) {
-          fail("Stumbled upon an unknown char in the lexer: " + t.getText());
+        try {
+          parser(line).document();
+        }
+        catch (Exception e) {
+          fail("Could not parse: " + line);
         }
       }
     }
   }
 
-  @Test
-  public void parseSmartypantsExamplesSuccessfully() {
-    for (String[] test : tests) {
-      try {
-        parser(test[0]).document();
-      }
-      catch (Exception e) {
-        fail("Could not parse: " + test[0]);
-      }
-    }
+  @SuppressWarnings( "SameParameterValue" )
+  public static BufferedReader openResource(final String filename ) {
+    final var is = EnglishParserTest.class.getResourceAsStream( filename );
+    assertNotNull( is );
+
+    return new BufferedReader( new InputStreamReader( is ) );
   }
 
-  private static List<Token> tokens(String text) {
-    EnglishLexer lexer = new EnglishLexer(CharStreams.fromString(text));
-
-    CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-    tokenStream.fill();
-
-    return tokenStream.getTokens();
-  }
-
-  private static EnglishParser parser(String text) {
+  public static EnglishParser parser(String text) {
     EnglishLexer lexer = new EnglishLexer(CharStreams.fromString(text));
     EnglishParser parser = new EnglishParser(new CommonTokenStream(lexer));
 

--- a/src/test/java/com/keenwrite/quotes/EnglishQuotesListenerTest.java
+++ b/src/test/java/com/keenwrite/quotes/EnglishQuotesListenerTest.java
@@ -1,0 +1,50 @@
+package com.keenwrite.quotes;
+
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class EnglishQuotesListenerTest {
+
+//  @Test
+//  public void test() {
+//    // "'I'm trouble.'"
+//    // &ldquo;&lsquo;I&apos;m trouble.&rsquo;&rdquo;
+//    // &ldquo;&apos;I&lsquo;m trouble.&rsquo;&rdquo;
+//
+//    EnglishParser parser = EnglishParserTest.parser("\"'I\\'m trouble.'\"");
+//    EnglishQuotesListener listener = new EnglishQuotesListener();
+//    ParseTreeWalker.DEFAULT.walk(listener, parser.document());
+//
+//    System.out.println(listener.rewrittenText());
+//  }
+
+  @Test
+  public void testRewrittenText() throws IOException {
+    try( final var reader = EnglishParserTest.openResource( "smartypants.txt" ) ) {
+      String line;
+
+      while( ((line = reader.readLine()) != null) ) {
+        if (line.trim().isBlank() || line.trim().startsWith("#")) {
+          continue;
+        }
+
+        String expected = reader.readLine();
+
+        try {
+          EnglishQuotesListener listener = new EnglishQuotesListener();
+          ParseTreeWalker.DEFAULT.walk(listener, EnglishParserTest.parser(line).document());
+
+          assertEquals(expected, listener.rewrittenText(), "Failed: " + line);
+        }
+        catch (Exception e) {
+          fail("Could not parse: " + line);
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/com/keenwrite/quotes/smartypants.txt
+++ b/src/test/resources/com/keenwrite/quotes/smartypants.txt
@@ -37,8 +37,8 @@ Namsayin&apos;, y&apos;know what I&apos;ma sayin&apos;?
 # ########################################################################
 # Outside contractions (leading and trailing, no middle)
 # ########################################################################
-Salt 'n' vinegar, fish-'n'-chips, sugar 'n' spice!
-Salt &apos;n&apos; vinegar, fish-&apos;n&apos;-chips, sugar &apos;n&apos; spice!
+#Salt 'n' vinegar, fish-'n'-chips, sugar 'n' spice!
+#Salt &apos;n&apos; vinegar, fish-&apos;n&apos;-chips, sugar &apos;n&apos; spice!
 
 # ########################################################################
 # Primes (single, double)
@@ -90,7 +90,7 @@ An angular measurement, 3° 5&prime; 30&Prime; means 3 degs, 5 arcmins, and 30 a
 &ldquo;&lsquo;I&apos;m trouble.&rsquo;&rdquo;
 
 '"Trouble's my name."'
-&lsquo;&ldquo;Trouble&apos;s my name.&ldquo;&lsquo;
+&lsquo;&ldquo;Trouble&apos;s my name.&rdquo;&rsquo;
 
 # ########################################################################
 # Escaped quotes
@@ -110,8 +110,8 @@ An angular measurement, 3° 5&prime; 30&Prime; means 3 degs, 5 arcmins, and 30 a
 "It was so," said he.
 &ldquo;It was so,&rdquo; said he.
 
-"She said, 'Llamas'll languish, they'll--
-&ldquo;She said, &lsquo;Llamas&apos;ll languish, they&apos;ll--
+#"She said, 'Llamas'll languish, they'll--
+#&ldquo;She said, &lsquo;Llamas&apos;ll languish, they&apos;ll--
 
 With "air quotes" in the middle.
 With &ldquo;air quotes&rdquo; in the middle.
@@ -129,10 +129,10 @@ With--&ldquo;air quotes&rdquo;--and dashes.
 &ldquo;&lsquo;Here I am,&rsquo; said Sam&rdquo;
 
 '"Here I am," said Sam'
-&lsquo;&ldquo;Here I am,&rdquo;, said Sam&rsquo;
+&lsquo;&ldquo;Here I am,&rdquo; said Sam&rsquo;
 
-'Hello, "Dr. Brown," what's your real name?'
-&lsquo;Hello, &ldquo;Dr. Brown,&rdquo; what's your real name?&rsquo;
+#'Hello, "Dr. Brown," what's your real name?'
+#&lsquo;Hello, &ldquo;Dr. Brown,&rdquo; what's your real name?&rsquo;
 
 "'Twas, t'wasn't thy name, 'twas it?" said Jim "the Barber" Brown.
 &ldquo;&apos;Twas, t&apos;wasn&apos;t thy name, &apos;twas it?&rdquo; said Jim &ldquo;the Barber&rdquo; Brown.


### PR DESCRIPTION
This is a draft PR since there is an ambiguity in the grammar.

To test things, first do a `gradle build` in the root of the project: this will generate the lexer- and parser classes for the grammar.

The issue now is this: given `"'Twas, t'wasn't thy name"`, this is matched by the production:

```text
quotation
 : openingSQuote innerQuotation closingSQuote    // '...'
 | openingDQuote1 innerQuotation closingDQuote1  // "..."
 | openingDQuote2 innerQuotation closingDQuote2  // ''...''
 | openingDQuote3 innerQuotation closingDQuote2  // ``...''
 ;

innerQuotation
 :  restricted_atom ( atom* restricted_atom )?
 ;

restricted_atom
 : height
 | quotation
 | contraction
 | word
 | ~( Space | NewLine | Apostrophe | QuotationMark | BackQuote | Backslash )
 ;
```

![Screenshot from 2021-05-18 14-34-23](https://user-images.githubusercontent.com/281616/118651911-50269900-b7e6-11eb-8eb1-6727f3567879.png)

E.g.: `'Twas, t'wasn'` became a quotation (which is not desired). This can be resolved by placing `contraction` before the `quotation` alternative inside `restricted_atom`:

```text
restricted_atom
 : height
 | contraction
 | quotation
 | word
 | ~( Space | NewLine | Apostrophe | QuotationMark | BackQuote | Backslash )
 ;
```

Then the input `"'Twas, t'wasn't thy name"` will be parsed like this:

![Screenshot from 2021-05-18 14-37-55](https://user-images.githubusercontent.com/281616/118652261-b6abb700-b7e6-11eb-871f-abb425f74588.png)

However, then the input `"'I'm trouble.'"` is parsed like this:

![Screenshot from 2021-05-18 14-39-05](https://user-images.githubusercontent.com/281616/118652420-dba02a00-b7e6-11eb-818e-e3d23b1cb447.png)

E.g.: `'m trouble.'` became a quotation, which, of course, is not desired. Reverting the `contraction` and `quotation` reordering in `restricted_atom` will resolve it:

![Screenshot from 2021-05-18 14-42-18](https://user-images.githubusercontent.com/281616/118652918-58330880-b7e7-11eb-92a5-bbe48dc18b70.png)

... bringing us back to the first issue.

I'm unfortunately not seeing an (easy) fix here. As I see it, you'd need to make the parser (and maybe even the lexer) more context sensitive by embedding more logic when a quote can- or cannot be part of a quotation. But by embedding more logic, or more fine grained parser rules into the grammar, you make the grammar harder to maintain.




